### PR TITLE
Updated processing of new widget to use construct function.

### DIFF
--- a/halloween-store/halloween-store.php
+++ b/halloween-store/halloween-store.php
@@ -282,13 +282,12 @@ function halloween_store_register_widgets() {
 class hs_widget extends WP_Widget {
 
     //process our new widget
-    function hs_widget() {
-		
+    public function __construct() {
         $widget_ops = array(
-			'classname'   => 'hs-widget-class',
-			'description' => __( 'Display Halloween Products','halloween-plugin' ) );
-        $this->WP_Widget( 'hs_widget', __( 'Products Widget','halloween-plugin'), $widget_ops );
-		
+            'classname' => 'hs-widget-class',
+            'description' => __('Display Halloween Products','halloween-plugin'),
+        );
+        parent::__construct( 'hs_widget', __( 'Products Widget', 'halloween-plugin'), $widget_ops);
     }
 
     //build our widget settings form


### PR DESCRIPTION
The "Professional WordPress: Design and Development" book had this updated, but this repo that the book linked to still used the depreciated function for processing a new widget and was throwing a warning.
